### PR TITLE
Fixed typo in comment

### DIFF
--- a/src/coin/Key.cpp
+++ b/src/coin/Key.cpp
@@ -15,7 +15,7 @@ std::string hexify(const PubKey& t) {
     return hexify(bytes);
 }
 */
-// Generate a private key from just the secret parameter
+// Generate a public key from just the secret parameter
 int EC_KEY_regenerate_key(EC_KEY *eckey, BIGNUM *priv_key)
 {
     int ok = 0;


### PR DESCRIPTION
Fixed a typo in Key.cpp.  The function which recovers a public key was described as recovering a private key.
