### PR TITLE
Removed x86 assembly, replaced with fast portable algorithm.

### DIFF
--- a/tests/merkletrie/merkletrie.cpp
+++ b/tests/merkletrie/merkletrie.cpp
@@ -27,13 +27,28 @@
 
 #include <stdint.h>
 
+//Portable algorithms from http://aggregate.org/MAGIC/
+unsigned uint32_t ones32(uint32_t x)
+{
+        /* 32-bit recursive reduction using SWAR...
+	   but first step is mapping 2-bit values
+	   into sum of 2 1-bit values in sneaky way
+	*/
+        x -= ((x >> 1) & 0x55555555);
+        x = (((x >> 2) & 0x33333333) + (x & 0x33333333));
+        x = (((x >> 4) + x) & 0x0f0f0f0f);
+        x += (x >> 8);
+        x += (x >> 16);
+        return(x & 0x0000003f);
+}
+
 static inline uint32_t log2(const uint32_t x) {
-    uint32_t y;
-    asm ( "\tbsr %1, %0\n"
-         : "=r"(y)
-         : "r" (x)
-         );
-    return y;
+    x |= (x >> 1);
+    x |= (x >> 2);
+    x |= (x >> 4);
+    x |= (x >> 8);
+    x |= (x >> 16);
+    return(ones32(x >> 1));
 }
 
 using namespace std;


### PR DESCRIPTION
Merkletrie.cpp uses inline assembly to calculate the log2 of a 32 bit integer.  This patch replaces it with portable C from http://aggregate.org/MAGIC/#Log2%20of%20an%20Integer which can actually be faster on platforms for which BSR is a microcode instruction.
