### PR TITLE
Make cryptoshi audit use standard Bitcoin signatures

### DIFF
--- a/src/coin/ExtendedKey.cpp
+++ b/src/coin/ExtendedKey.cpp
@@ -269,9 +269,6 @@ Key::Key(uint256 hash, const Data& signature) {
     if (rec<0 || rec>=3)
         throw runtime_error("Key::Key signature malformed");
 
-    if (!((signature[0] - 27) & 4))
-        throw runtime_error("Key::Key verification of uncompressed keys not supported");
-    
     ECDSA_SIG *sig = ECDSA_SIG_new();
     BN_bin2bn(&p64[0],  32, sig->r);
     BN_bin2bn(&p64[32], 32, sig->s);


### PR DESCRIPTION
`cryptoshi audit` was using some non-standard signature format. This patch replaces that with fully compliant Bitcoin signatures. I think that's better for future audits, so that other compatible tools can be written easily, such as [easy-audit](https://github.com/justmoon/easy-audit).

Changes:
- Include varint sizes in message serialization before hash
- Support for uncompressed pubkey addresses
- Remove address from signed message (not needed)
