### PR TITLE
Implement name_scan and name_filter.

### DIFF
--- a/applications/libcoind/libcoind.cpp
+++ b/applications/libcoind/libcoind.cpp
@@ -178,6 +178,7 @@ int main(int argc, char* argv[])
             server.registerMethod(method_ptr(new NameShow(node)));
             server.registerMethod(method_ptr(new NameHistory(node)));
             server.registerMethod(method_ptr(new NameScan(node)));
+            server.registerMethod(method_ptr(new NameFilter(node)));
         }
         
         /// The Pool enables you to run a backend for a miner, i.e. your private pool, it also enables you to participate in the "Name of Pool"

--- a/include/coinChain/BlockChain.h
+++ b/include/coinChain/BlockChain.h
@@ -273,6 +273,7 @@ public:
     NameDbRow getNameRow(const std::string& name) const;
     std::vector<NameDbRow> getNameHistory(const std::string& name) const;
     std::vector<NameDbRow> getNameScan(const std::string& start, unsigned cnt) const;
+    std::vector<NameDbRow> getNameFilter(const std::string& pattern, unsigned maxage, unsigned from, unsigned nb) const;
     
     /// Get the locator for the best index
     const BlockLocator& getBestLocator() const;

--- a/include/coinChain/Database.h
+++ b/include/coinChain/Database.h
@@ -1169,6 +1169,8 @@ namespace sqliterate {
         sqlite3 *_db;
         typedef std::map<const char *, StatementBase> Statements;
         mutable Statements _statements;
+
+        void registerFunctions();
     };
 }
 

--- a/include/coinName/NameGetRPC.h
+++ b/include/coinName/NameGetRPC.h
@@ -52,7 +52,7 @@ protected:
    * @param unique Whether we should enforce unique names.
    * @return The corresponding JSON object.
    */
-  json_spirit::Value processNameRows (const std::vector<NameDbRow> arr,
+  json_spirit::Array processNameRows (const std::vector<NameDbRow>& arr,
                                       bool unique) const;
 
 public:
@@ -155,6 +155,39 @@ public:
     : NameGetMethod(n)
   {
     setName ("name_scan");
+  }
+
+  /**
+   * Perform the call.
+   * @param params Parameters given to call.
+   * @param fHelp Help requested?
+   * @return JSON result.
+   */
+  json_spirit::Value operator() (const json_spirit::Array& params, bool fHelp);
+
+};
+
+/* ************************************************************************** */
+/* name_filter implementation.  */
+
+/**
+ * Implementation of the name_filter method to query for names matching
+ * a given regexp.
+ */
+class COINNAME_EXPORT NameFilter : public NameGetMethod
+{
+
+public:
+
+  /**
+   * Construct it for the given node.
+   * @param n Node to use.
+   */
+  explicit inline
+  NameFilter (Node& n)
+    : NameGetMethod(n)
+  {
+    setName ("name_filter");
   }
 
   /**

--- a/src/coinName/NameGetRPC.cpp
+++ b/src/coinName/NameGetRPC.cpp
@@ -26,8 +26,8 @@
 /* ************************************************************************** */
 /* NameGetMethod base class.  */
 
-json_spirit::Value
-NameGetMethod::processNameRows (const std::vector<NameDbRow> arr,
+json_spirit::Array
+NameGetMethod::processNameRows (const std::vector<NameDbRow>& arr,
                                 bool unique) const
 {
   std::set<Evaluator::Value> namesSeen;
@@ -129,4 +129,74 @@ NameScan::operator() (const json_spirit::Array& params, bool fHelp)
   const std::vector<NameDbRow> rows = chain.getNameScan (start, count);
 
   return processNameRows (rows, true);
+}
+
+/* ************************************************************************** */
+/* name_filter implementation.  */
+
+json_spirit::Value
+NameFilter::operator() (const json_spirit::Array& params, bool fHelp)
+{
+  if (fHelp || params.size () > 5)
+    throw RPC::error (RPC::invalid_params,
+      "name_filter [<pattern> [<maxage>=36000 [from=0 nb=0 [\"stat\"]]]]\n"
+      "Scan for names matching <pattern>.  Only look into"
+      " the last <maxage> blocks.\n"
+      "Return at most <nb> results (0 means all) and return them from the\n"
+      "entry with number <from> onward.\n\n"
+      "If \"stat\" is given as fifth argument, print statistics instead of\n"
+      "returning the results by themselves.");
+
+  std::string pattern;
+  if (params.size () >= 1)
+    {
+      /* FIXME: Correctly handle integer parameters (convert to string).  */
+      pattern = params[0].get_str ();
+    }
+  else
+    pattern = "";
+
+  unsigned maxage = 36000, from = 0, nb = 0;
+  if (params.size () >= 2)
+    maxage = params[1].get_int ();
+  if (params.size () >= 3)
+    from = params[2].get_int ();
+  if (params.size () >= 4)
+    nb = params[3].get_int ();
+
+  /* Only allow "from" to be non-zero if "nb" is set.  "from" non-zero
+     without "nb" makes no real sense, especially since the order of names
+     is not strictly defined.  It also makes things complicated with the
+     SQL query.  */
+  if (from > 0 && nb == 0)
+    throw RPC::error (RPC::invalid_params,
+                      "<from> can only be non-zero if <nb> is set");
+
+  bool stat = false;
+  if (params.size () >= 5)
+    {
+      if (params[4].get_str () == "stat")
+        stat = true;
+      else
+        throw RPC::error (RPC::invalid_params,
+                          "invalid fifth argument, expected \"stat\"");
+    }
+
+  /* Query for the data in the block chain database.  */
+  const BlockChain& chain = node.blockChain ();
+  const std::vector<NameDbRow> rows = chain.getNameFilter (pattern, maxage, from, nb);
+
+  /* Convert to JSON array.  */
+  json_spirit::Array res = processNameRows (rows, true);
+
+  /* Handle stats flag if we have it.  */
+  if (stat)
+    {
+      json_spirit::Object stats;
+      stats.push_back (json_spirit::Pair ("blocks", chain.getBestHeight ()));
+      stats.push_back (json_spirit::Pair ("count", res.size ()));
+      return stats;
+    }
+
+  return res;
 }


### PR DESCRIPTION
This pull request implements name_scan and name_filter for Namecoin.  For this, it also adds a "regexp" user-defined function to the SQLite instance used, based on Boost's xpressive.
