### PR TITLE
Added Namecoin checkpoint at 182k

### DIFF
--- a/src/coinChain/Chain.cpp
+++ b/src/coinChain/Chain.cpp
@@ -430,6 +430,7 @@ NamecoinChain::NamecoinChain() : Chain("namecoin", "NMC", 8), _genesis("00000000
     ( 30240, uint256("0xe1c8c862ff342358384d4c22fa6ea5f669f3e1cdcf34111f8017371c3c0be1da"))
     ( 57000, uint256("0xaa3ec60168a0200799e362e2b572ee01f3c3852030d07d036e0aa884ec61f203"))
     (112896, uint256("0x73f880e78a04dd6a31efc8abf7ca5db4e262c4ae130d559730d6ccb8808095bf"))
+    (182000, uint256("0xd47b4a8fd282f635d66ce34ebbeb26ffd64c35b41f286646598abfd813cba6d9"))
     ;
     
 }


### PR DESCRIPTION
Latest Namecoin release added a checkpoint at block 182k; this PR does the same for the libcoin implementation.  Fixes https://github.com/libcoin/libcoin/issues/59
