### PR TITLE
Fix some clang warnings

### DIFF
--- a/include/coinChain/BlockChain.h
+++ b/include/coinChain/BlockChain.h
@@ -37,7 +37,7 @@
 
 class Transaction;
 class NameOperation;
-class NameDbRow;
+struct NameDbRow;
 
 typedef std::vector<Transaction> Transactions;
 typedef std::map<uint256, Block> Branches;

--- a/src/coinWallet/Wallet.cpp
+++ b/src/coinWallet/Wallet.cpp
@@ -391,8 +391,10 @@ bool Wallet::IsConfirmed(const CWalletTx& tx) const
             return false;
         
         if (mapPrev.empty())
+            {
             BOOST_FOREACH(const MerkleTx& mtx, tx.vtxPrev)
                 mapPrev[tx.getHash()] = &mtx;
+            }
         
         BOOST_FOREACH(const Input& txin, ptx->getInputs())
             {

--- a/src/coinWallet/WalletRPC.cpp
+++ b/src/coinWallet/WalletRPC.cpp
@@ -115,11 +115,12 @@ Value GetBalance::operator()(const Array& params, bool fHelp) {
             list<pair<ChainAddress, int64_t> > listReceived;
             list<pair<ChainAddress, int64_t> > listSent;
             wtx.GetAmounts(allGeneratedImmature, allGeneratedMature, listReceived, listSent, allFee, strSentAccount);
-            if (_wallet.getDepthInMainChain(wtx.getHash()) >= nMinDepth)
+            if (_wallet.getDepthInMainChain(wtx.getHash()) >= nMinDepth) {
                 BOOST_FOREACH(const PAIRTYPE(ChainAddress,int64_t)& r, listReceived)
-                nBalance += r.second;
+                    nBalance += r.second;
+            }
             BOOST_FOREACH(const PAIRTYPE(ChainAddress,int64_t)& r, listSent)
-            nBalance -= r.second;
+                nBalance -= r.second;
             nBalance -= allFee;
             nBalance += allGeneratedMature;
         }
@@ -615,6 +616,7 @@ void ListMethod::listTransactions(const CWalletTx& wtx, const string& strAccount
     
     // Received
     if (listReceived.size() > 0 && _wallet.getDepthInMainChain(wtx.getHash()) >= nMinDepth)
+    {
         BOOST_FOREACH(const PAIRTYPE(ChainAddress, int64_t)& r, listReceived)
         {
         string account;
@@ -632,6 +634,7 @@ void ListMethod::listTransactions(const CWalletTx& wtx, const string& strAccount
             ret.push_back(entry);
             }
         }
+    }
 }
 
 void ListMethod::acEntryToJSON(const CAccountingEntry& acentry, const string& strAccount, Array& ret)

--- a/src/coinWallet/WalletTx.cpp
+++ b/src/coinWallet/WalletTx.cpp
@@ -258,9 +258,10 @@ void CWalletTx::AddSupportingTransactions(const BlockChain& blockChain)
             int nDepth = blockChain.setMerkleBranch(tx);
             vtxPrev.push_back(tx);
             
-            if (nDepth < COPY_DEPTH)
+            if (nDepth < COPY_DEPTH) {
                 BOOST_FOREACH(const Input& txin, tx.getInputs())
-                vWorkQueue.push_back(txin.prevout().hash);
+                    vWorkQueue.push_back(txin.prevout().hash);
+            }
         }
     }
     //}


### PR DESCRIPTION
Note that I've sticked to braces placement style used locally, but man it's inconsistent.

While here, deobfuscate some whitespace.