### PR TITLE
Use dl library provided by cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,9 +154,13 @@ IF(UNIX AND NOT ANDROID)
     # Some Unicies need explicit linkage to the Math library or the build fails.
     FIND_LIBRARY(MATH_LIBRARY m)
 
-    FIND_LIBRARY(DL_LIBRARY dl)
-    IF(NOT DL_LIBRARY)
-        SET(DL_LIBRARY "") # change from NOTFOUND to empty when passed to linker
+    IF(CMAKE_DL_LIBS)
+        SET(DL_LIBRARY "${CMAKE_DL_LIBS}")
+    ELSE()
+        FIND_LIBRARY(DL_LIBRARY dl)
+        IF(NOT DL_LIBRARY)
+            SET(DL_LIBRARY "") # change from NOTFOUND to empty when passed to linker
+        ENDIF()
     ENDIF()
 
     IF( CMAKE_SYSTEM MATCHES "Linux" )


### PR DESCRIPTION
Actually, this whole block of libdl detection code may be removed and all ${DL_LIBRARY} references just replaced by ${CMAKE_DL_LIBS}, but this variable is only available since cmake 2.6, and you seem to still support 2.4.
