### PR TITLE
Add build artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ cmake_uninstall.cmake
 include/coin/Config.h
 include/coin/Version.h
 packaging/ld.so.conf.d/libcoin.conf
+bin/
+lib/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,11 @@ src/bitcoind
 *.o
 *.patch
 .bitcoin
+CMakeCache.txt
+**/CMakeFiles/
+**/Makefile
+**/cmake_install.cmake
+cmake_uninstall.cmake
+include/coin/Config.h
+include/coin/Version.h
+packaging/ld.so.conf.d/libcoin.conf


### PR DESCRIPTION
Include build targets and intermediate files in .gitignore so they don't show up in `git status` after building.
